### PR TITLE
improve quail-ui skill structure

### DIFF
--- a/.github/workflows/skill-apply-optimize.yml
+++ b/.github/workflows/skill-apply-optimize.yml
@@ -1,0 +1,19 @@
+name: Apply Skill Optimization
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  apply:
+    if: >-
+      github.event.issue.pull_request &&
+      contains(github.event.comment.body, '/apply-optimize')
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: tesslio/skill-review-and-optimize@d81583861aaf29d1da7f10e6539efef4e27b0dd5
+        with:
+          mode: 'apply'

--- a/.github/workflows/skill-review.yml
+++ b/.github/workflows/skill-review.yml
@@ -1,0 +1,17 @@
+name: Skill Review & Optimize
+on:
+  pull_request:
+    paths: ['**/SKILL.md']
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: tesslio/skill-review-and-optimize@d81583861aaf29d1da7f10e6539efef4e27b0dd5
+        with:
+          optimize: 'true'
+          tessl-token: ${{ secrets.TESSL_API_TOKEN }}

--- a/quaily_ui_skill/SKILL.md
+++ b/quaily_ui_skill/SKILL.md
@@ -1,50 +1,46 @@
 ---
 name: use-quail-ui-in-frontend-project
-description: Use this skill when integrating Quail UI into a Vue 3 frontend, migrating an existing screen to Quail UI components, or needing the library's themes, tokens, icons, demo-backed usage patterns, and agent-facing onboarding docs.
+description: Use this skill when adding, migrating, or styling Vue 3 components with Quail UI — buttons, dialogs, inputs, tabs, menus, icons, themes (light/dark/morph), tokens, SCSS utilities, or layout helpers.
 ---
 
 # Quail UI Frontend Integration
 
-Read [`docs/ai-agent-guide.md`](https://github.com/quailyquaily/quail-ui/blob/master/docs/ai-agent-guide.md) first. It is the primary onboarding document for AI agents and already contains:
-
-- installation patterns
-- plugin vs named-import usage
-- theme helpers and token families
-- typography, utility classes, and common CSS patterns
-- demo coverage under `src/app/home/*`
-- the exported component catalog
-- the icon catalog
-- current API gotchas where older docs are stale
+Read [`docs/ai-agent-guide.md`](https://github.com/quailyquaily/quail-ui/blob/master/docs/ai-agent-guide.md) first. It is the primary reference and covers installation, plugin vs named-import usage, theme helpers, token families, typography, utility classes, the component and icon catalogs, demo coverage, and current API gotchas.
 
 ## Workflow
 
-1. Open [`docs/ai-agent-guide.md`](https://github.com/quailyquaily/quail-ui/blob/master/docs/ai-agent-guide.md).
-2. Default to `app.use(QuailUI)` plus `import "quail-ui/style.css"` unless the task clearly needs selective registration.
-3. Prefer exported Quail components, icons, theme helpers, and utility classes over custom lookalikes.
-4. Copy composition patterns from [`src/app/home/`](https://github.com/quailyquaily/quail-ui/tree/master/src/app/home).
-5. If a prop or event is unclear, inspect the source in [`src/components/common/`](https://github.com/quailyquaily/quail-ui/tree/master/src/components/common) before writing code.
+1. Default to `app.use(QuailUI)` plus `import "quail-ui/style.css"` unless the task clearly needs selective registration.
+2. Prefer exported Quail components, icons, theme helpers, and utility classes over custom lookalikes.
+3. Copy composition patterns from [`src/app/home/`](https://github.com/quailyquaily/quail-ui/tree/master/src/app/home).
+4. If a prop or event is unclear, inspect the source in [`src/components/common/`](https://github.com/quailyquaily/quail-ui/tree/master/src/components/common) before writing code.
 
-## Files To Read On Demand
+## Files to Read On Demand
 
-- [`docs/ai-agent-guide.md`](https://github.com/quailyquaily/quail-ui/blob/master/docs/ai-agent-guide.md)
+Start with the agent guide. Read the others only when the task touches that area.
+
+**Core exports**
 - [`src/index.ts`](https://github.com/quailyquaily/quail-ui/blob/master/src/index.ts)
 - [`src/components/common/index.ts`](https://github.com/quailyquaily/quail-ui/blob/master/src/components/common/index.ts)
 - [`src/components/icons/index.ts`](https://github.com/quailyquaily/quail-ui/blob/master/src/components/icons/index.ts)
+
+**Theming and styles**
 - [`src/theme/index.ts`](https://github.com/quailyquaily/quail-ui/blob/master/src/theme/index.ts)
 - [`src/styles/base.scss`](https://github.com/quailyquaily/quail-ui/blob/master/src/styles/base.scss)
 - [`src/styles/layout/helper.scss`](https://github.com/quailyquaily/quail-ui/blob/master/src/styles/layout/helper.scss)
 - [`src/styles/component.scss`](https://github.com/quailyquaily/quail-ui/blob/master/src/styles/component.scss)
 - [`src/styles/theme/morph.scss`](https://github.com/quailyquaily/quail-ui/blob/master/src/styles/theme/morph.scss)
+
+**Demo patterns**
 - [`src/app/home.vue`](https://github.com/quailyquaily/quail-ui/blob/master/src/app/home.vue)
 - [`src/app/home/`](https://github.com/quailyquaily/quail-ui/tree/master/src/app/home)
 
 ## Rules
 
 - Prefer the real component APIs from source over older README snippets.
-- Remember the current gotchas from the guide:
+- API gotchas (source of truth is the agent guide):
   - no `QFormItem`
   - no `QInputWithButton`; use `QTextFieldWithButton`
-  - `QInput` uses `inputType`
-  - `QTextarea` uses `max`
+  - `QInput` uses `inputType`, not `type`
+  - `QTextarea` uses `max`, not `maxlength`
   - `QPagination` uses `totalPage`, `hasPrev`, `hasNext`
-  - selectors emit `change` instead of `v-model`
+  - selectors emit `change` instead of supporting `v-model`


### PR DESCRIPTION
hey @quailyquaily, thanks for building quail-ui. really like the dedicated AI agent entry point with the agent guide. Kudos on soon reaching `50` stars! I've just starred it.

ran your use-quail-ui-in-frontend-project skill through agent evals and spotted a few quick wins that took it from `~84%` to `~94%` performance:

- expanded description with component names like _buttons, dialogs, inputs, tabs, icons_ + theme terms

- removed redundant agent guide summary + grouped on-demand files by category for progressive disclosure

- clarified API gotchas with contrast terms like _not `type`_, _not `maxlength`_

also added a GitHub Action that auto-reviews any skill.md changed in a PR (includes min permissions, uses a pinned action version, only posts a review comment).

this means that it gives you and your contributors an instant quality signal before you have to review yourself (no signup, no tokens needed).

optionally, you can enable _optimize_ mode by adding a [token](https://tessl.io/account/api-keys) as `TESSL_API_TOKEN` in your repo secrets - when enabled, the action suggests improvements you can accept by commenting `/apply-optimize`.

these were easy changes to bring the skill in line with what **performs well against Anthropic's best practices**. honest disclosure, I work at tessl.io where we build tooling around this. not a pitch, just fixes that were straightforward to make! happy to answer any questions on the changes.